### PR TITLE
Disable SSL in the MERN app

### DIFF
--- a/server/routers/mongo.js
+++ b/server/routers/mongo.js
@@ -41,7 +41,7 @@ module.exports = function(app){
 
 	const options = {
 		useMongoClient: true,
-		ssl: true,
+		ssl: false,
 		sslValidate: false,
 		poolSize: 1,
 		reconnectTries: 1


### PR DESCRIPTION
The Docker compose file for Mongo is not configured to use SSL, but the app is trying to connect using SSL.

Either the app needs to be updated to not attempt to use SSL (this patch), or the Mongo instance needs to be configured to use SSL in Docker compose.

Closes #22